### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["work"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,13 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
+// Declare process to avoid requiring Node types during build
+declare const process: {
+  env?: Record<string, string | undefined>
+}
+const repoName = process.env?.GITHUB_REPOSITORY?.split('/')[1] ?? ''
+
 export default defineConfig({
+  base: repoName ? `/${repoName}/` : '/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy site to GitHub Pages
- configure Vite base path dynamically for GitHub Pages

## Testing
- `npm run lint` *(fails: 13 errors for unused variables)*
- `npm run build` *(fails: TypeScript errors for unused variables)*
- `npx eslint vite.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c47fe6a9c083339f423937d1d7baf7